### PR TITLE
chore(ci): upgrade github actions and Node.js to 22

### DIFF
--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: 24 # semantic-release requires at least this version, or 22 LTS
     # Ensure npm 11.5.1 or later is installed for Trusted publishing

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify Android'
@@ -32,7 +32,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Verify iOS'
@@ -43,7 +43,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'
@@ -57,7 +57,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: 'Setup Tools'
         uses: ./.github/actions/setup-tools
       - name: 'Prepare example app'

--- a/.github/workflows/publish_android_maven_central.yml
+++ b/.github/workflows/publish_android_maven_central.yml
@@ -27,12 +27,12 @@ jobs:
     permissions:
       contents: read
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}
     - name: set up JDK 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '21'
         distribution: 'zulu'

--- a/.github/workflows/publish_ios_cocoapods_trunk.yml
+++ b/.github/workflows/publish_ios_cocoapods_trunk.yml
@@ -18,10 +18,10 @@ jobs:
       - run: sudo xcode-select --switch /Applications/Xcode_16.app
       - run: xcrun simctl list > /dev/null
       - run: xcodebuild -downloadPlatform iOS
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
-      - uses: actions/checkout@v3
+          node-version: 22
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/release_plugin.yml
+++ b/.github/workflows/release_plugin.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.CAP_GH_RELEASE_TOKEN }}

--- a/.github/workflows/reusable_build.yml
+++ b/.github/workflows/reusable_build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}

--- a/.github/workflows/reusable_lint.yml
+++ b/.github/workflows/reusable_lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: 'macos-15'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 

--- a/.github/workflows/reusable_setup.yml
+++ b/.github/workflows/reusable_setup.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.THE_GH_RELEASE_TOKEN || github.token }}
 


### PR DESCRIPTION
- Upgrade actions/checkout v4 → v5 (https://github.com/actions/checkout/releases/tag/v5.0.0)
- Upgrade actions/setup-node v4 → v6 (https://github.com/actions/setup-node/releases/tag/v6.0.0)
- Upgrade actions/setup-java v4 → v5 (https://github.com/actions/setup-java/releases/tag/v5.0.0)
- Upgrade Node from 20 to 22 across all workflows