### PR TITLE
fix(web): don't throw if vibrate is not supported

### DIFF
--- a/src/web.ts
+++ b/src/web.ts
@@ -63,8 +63,6 @@ export class HapticsWeb extends WebPlugin implements HapticsPlugin {
   private vibrateWithPattern(pattern: number[]) {
     if (navigator.vibrate) {
       navigator.vibrate(pattern);
-    } else {
-      throw this.unavailable('Browser does not support the vibrate API');
     }
   }
 }


### PR DESCRIPTION
The `README.md` states "On devices that don't have Taptic Engine or Vibrator, the API calls will resolve without performing any action.". 

Right now on web this plugin throws an exception if the vibrate api is not supported, this seems to be out of line with the `README.md` thus I propose changing the web code to no throw anymore. (Related [issue](https://github.com/ionic-team/capacitor-plugins/issues/2169))