### PR TITLE
fix(ios): prevent thread overload by reusing CHHapticEngine

### DIFF
--- a/ios/Sources/HapticsPlugin/Haptics.swift
+++ b/ios/Sources/HapticsPlugin/Haptics.swift
@@ -6,6 +6,46 @@ import CoreHaptics
 
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
 
+    private var hapticEngine: CHHapticEngine?
+    private var idleTimer: Timer?
+    private let idleInterval: TimeInterval = 5.0
+
+    private func initializeEngine() {
+        do {
+            let engine = try CHHapticEngine()
+            engine.resetHandler = { [weak self] in
+                do {
+                    try self?.hapticEngine?.start()
+                } catch {
+                    self?.hapticEngine = nil
+                }
+            }
+            engine.stoppedHandler = { [weak self] _ in
+                self?.hapticEngine = nil
+            }
+            try engine.start()
+            hapticEngine = engine
+        } catch {
+            hapticEngine = nil
+        }
+    }
+
+    private func resetIdleTimer(after duration: TimeInterval) {
+        idleTimer?.invalidate()
+        idleTimer = Timer.scheduledTimer(
+            withTimeInterval: duration + idleInterval, repeats: false
+        ) { [weak self] _ in
+            self?.shutdownEngine()
+        }
+    }
+
+    private func shutdownEngine() {
+        idleTimer?.invalidate()
+        idleTimer = nil
+        hapticEngine?.stop(completionHandler: nil)
+        hapticEngine = nil
+    }
+
     @objc public func impact(_ impactStyle: UIImpactFeedbackGenerator.FeedbackStyle) {
         let generator = UIImpactFeedbackGenerator(style: impactStyle)
         generator.impactOccurred()
@@ -38,16 +78,17 @@ import CoreHaptics
 
     @objc public func vibrate(_ duration: Double) {
         if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
+            if hapticEngine == nil {
+                initializeEngine()
+            }
+            resetIdleTimer(after: duration)
+
+            guard let engine = hapticEngine else {
+                vibrate()
+                return
+            }
+
             do {
-                let engine = try CHHapticEngine()
-                try engine.start()
-                engine.resetHandler = { [] in
-                    do {
-                        try engine.start()
-                    } catch {
-                        self.vibrate()
-                    }
-                }
                 let intensity = CHHapticEventParameter(parameterID: .hapticIntensity, value: 1.0)
                 let sharpness = CHHapticEventParameter(parameterID: .hapticSharpness, value: 1.0)
 


### PR DESCRIPTION
## Description

This PR addresses an issue where calling `Haptics.vibrate()` rapidly (e.g., from a fast-scrolling picker in my case) causes the app to hang or crash on iOS. The problem stems from creating a new `CHHapticEngine` instance on each call, which leads to excessive thread creation and eventual system overload.

Solution:
- Reuse a single `CHHapticEngine` instance across multiple vibration calls
- Shut down the engine after `duration + 5s` of inactivity, so the idle countdown starts after the vibration finishes
- Handle engine lifecycle with `resetHandler` (restarts engine after server recovery) and `stoppedHandler` (clears the reference on external stops like audio interruptions or app suspension)

## Change Type
- [x] Fix

## Rationale / Problems Fixed

Continuation of ionic-team/capacitor-plugins#2340, moved here per maintainer guidance since the haptics plugin now lives in its own repository.

Related: https://github.com/ionic-team/capacitor-haptics/issues/7

Creating a new `CHHapticEngine` per `vibrate()` call spawns threads that accumulate faster than the system can reclaim them. Under rapid-fire usage (pickers, scroll-driven haptics), this leads to thread exhaustion, UI freezes, and eventual crashes.

## Tests or Reproductions

- Rapidly call `Haptics.vibrate()` from a picker/scroll, confirm no freeze or crash
- Call `vibrate(duration)` with a long duration (e.g. 5s), confirm vibration completes fully before engine shuts down
- Trigger an audio session interruption (e.g. phone call) mid-session, confirm haptics recover on next use
- Verify fallback to `AudioServicesPlayAlertSound` on devices without haptic support

## Platforms Affected
- [x] iOS

## Notes / Comments

This also addresses review feedback from the original PR (ionic-team/capacitor-plugins#2340):
- Removed redundant `supportsHaptics` check inside `initializeEngine()` since it's already guarded in the caller
- Idle timer now accounts for vibration duration (`duration + 5s`) instead of a flat 5s countdown
- Added `resetHandler` and `stoppedHandler` for proper engine lifecycle management following Apple's recommended patterns