### PR TITLE
perf(ios): reuse and pre-prepare feedback generators to reduce impact latency

### DIFF
--- a/ios/Sources/HapticsPlugin/Haptics.swift
+++ b/ios/Sources/HapticsPlugin/Haptics.swift
@@ -6,14 +6,37 @@ import CoreHaptics
 
     var selectionFeedbackGenerator: UISelectionFeedbackGenerator?
 
+    // Reuse and keep the feedback generators in a prepared state. Apple's docs
+    // recommend calling prepare() ahead of time so the Taptic Engine does not
+    // cold-start on the first impact, which otherwise adds perceptible latency.
+    // Generators are lazily created (and prepared) on first use and re-prepared
+    // after every event so the next trigger stays warm.
+    private lazy var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
+    private lazy var notificationGenerator: UINotificationFeedbackGenerator = {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        return generator
+    }()
+
+    private func impactGenerator(for style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
+        if let generator = impactGenerators[style] {
+            return generator
+        }
+        let generator = UIImpactFeedbackGenerator(style: style)
+        generator.prepare()
+        impactGenerators[style] = generator
+        return generator
+    }
+
     @objc public func impact(_ impactStyle: UIImpactFeedbackGenerator.FeedbackStyle) {
-        let generator = UIImpactFeedbackGenerator(style: impactStyle)
+        let generator = impactGenerator(for: impactStyle)
         generator.impactOccurred()
+        generator.prepare()
     }
 
     @objc public func notification(_ notificationType: UINotificationFeedbackGenerator.FeedbackType) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.notificationOccurred(notificationType)
+        notificationGenerator.notificationOccurred(notificationType)
+        notificationGenerator.prepare()
     }
 
     @objc public func selectionStart() {


### PR DESCRIPTION
## Description

`impact()` and `notification()` created a brand-new `UIImpactFeedbackGenerator` / `UINotificationFeedbackGenerator` on every call and never called `prepare()`. That forces the Taptic Engine to cold-start on each trigger, which adds perceptible latency to the first (and every subsequent) impact.

This PR caches one generator per impact style plus the notification generator, calls `prepare()` when each is created, and re-`prepare()`s after every event so the next trigger stays warm. It mirrors the prepared-generator pattern the plugin already uses for `selectionStart()` / `selectionChanged()`.

No public API change. `selectionStart/Changed/End` and both `vibrate(...)` overloads are untouched.

## Context

Apple's [`prepare()` documentation](https://developer.apple.com/documentation/uikit/uifeedbackgenerator/prepare()) recommends preparing a feedback generator ahead of time so the Taptic Engine is warm when feedback is triggered, reducing latency. The current implementation never does this for impact/notification, so the engine cold-starts on each call. We observed a clear, perceptible improvement on a physical device after switching to cached + prepared generators.

(This is independent of, and does not overlap with, the `vibrate()` / `CHHapticEngine` work in #24 — that PR owns the `vibrate(duration)` path; this one only touches `impact`/`notification`.)

## Type of changes

- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

(Performance refactor — non-breaking, no API change.)

## Platforms affected

- [ ] Android
- [x] iOS
- [ ] Web

## Tests

- Verified `npm run lint` (eslint + prettier + swiftlint) passes with 0 violations.
- Verified `npm run verify:web` builds.
- Manually tested on a physical iOS device: impact/notification feedback fires with noticeably lower first-trigger latency than the stock create-per-call implementation, and repeated triggers stay warm. Selection and vibrate behavior unchanged.

### Screenshots (if appropriate)

N/A (haptic feedback is not visual).
